### PR TITLE
Improve emergency flag caching and PenguBook bet history

### DIFF
--- a/src/commands/pip_safety.ts
+++ b/src/commands/pip_safety.ts
@@ -24,10 +24,10 @@ export default async function pipSafety(i: ChatInputCommandInteraction) {
 }
 
 async function handleLimits(i: ChatInputCommandInteraction) {
-  const maxDailyLoss = i.options.getInteger('max_daily_loss');
-  const maxDailyPredictions = i.options.getInteger('max_daily_predictions');
+  const maxDailyLossInput = i.options.getInteger('max_daily_loss');
+  const maxDailyPredictionsInput = i.options.getInteger('max_daily_predictions');
 
-  if (!maxDailyLoss && !maxDailyPredictions) {
+  if (maxDailyLossInput == null && maxDailyPredictionsInput == null) {
     // Show current limits
     const status = await responsibleGaming.getUserStatus(i.user.id);
 
@@ -76,8 +76,8 @@ async function handleLimits(i: ChatInputCommandInteraction) {
 
   // Update limits
   const result = await responsibleGaming.updateUserLimits(i.user.id, {
-    maxDailyLoss,
-    maxDailyPredictions
+    maxDailyLoss: maxDailyLossInput ?? undefined,
+    maxDailyPredictions: maxDailyPredictionsInput ?? undefined
   });
 
   const embed = new EmbedBuilder()

--- a/src/services/emergency_controls.ts
+++ b/src/services/emergency_controls.ts
@@ -2,6 +2,29 @@
 import { prisma } from "./db.js";
 import { predictionMarkets } from "./prediction_markets.js";
 
+const FEATURE_FLAG_CACHE_TTL_MS = 30_000;
+
+interface CachedFlag {
+  value: boolean;
+  expiresAt: number;
+}
+
+let achievementsFlagCache: CachedFlag | null = null;
+let streakProtectionFlagCache: CachedFlag | null = null;
+
+function setAchievementsCache(value: boolean) {
+  achievementsFlagCache = { value, expiresAt: Date.now() + FEATURE_FLAG_CACHE_TTL_MS };
+}
+
+function setStreakProtectionCache(value: boolean) {
+  streakProtectionFlagCache = { value, expiresAt: Date.now() + FEATURE_FLAG_CACHE_TTL_MS };
+}
+
+export function clearFeatureFlagCache() {
+  achievementsFlagCache = null;
+  streakProtectionFlagCache = null;
+}
+
 interface EmergencyState {
   predictionsDisabled: boolean;
   tippingDisabled: boolean;
@@ -49,6 +72,9 @@ export class EmergencyControlsService {
           streakProtectionEnabled: false
         }
       });
+
+      setAchievementsCache(false);
+      setStreakProtectionCache(false);
 
       // Cancel all active prediction markets if predictions are disabled
       if (shutdownConfig.predictionsDisabled) {
@@ -105,6 +131,9 @@ export class EmergencyControlsService {
           streakProtectionEnabled: true
         }
       });
+
+      setAchievementsCache(true);
+      setStreakProtectionCache(true);
 
       const recoveryConfig = {
         predictionsEnabled: params.enablePredictions ?? true,
@@ -373,8 +402,12 @@ export class EmergencyControlsService {
           "emergencyMode" = true,
           "withdrawalsPaused" = true,
           "tippingPaused" = true,
-          "achievementsEnabled" = false
+          "achievementsEnabled" = false,
+          "streakProtectionEnabled" = false
       `;
+
+      setAchievementsCache(false);
+      setStreakProtectionCache(false);
 
       // Cancel all active markets immediately
       await prisma.$executeRaw`
@@ -404,6 +437,52 @@ export class EmergencyControlsService {
       };
     }
   }
+}
+
+async function loadAchievementsFlag(): Promise<boolean> {
+  try {
+    const config = await prisma.appConfig.findFirst({
+      select: { achievementsEnabled: true }
+    });
+    return config?.achievementsEnabled ?? true;
+  } catch (error) {
+    console.error('Failed to load achievements flag:', error);
+    return true;
+  }
+}
+
+async function loadStreakProtectionFlag(): Promise<boolean> {
+  try {
+    const config = await prisma.appConfig.findFirst({
+      select: { streakProtectionEnabled: true }
+    });
+    return config?.streakProtectionEnabled ?? true;
+  } catch (error) {
+    console.error('Failed to load streak protection flag:', error);
+    return true;
+  }
+}
+
+export async function areAchievementsEnabled(): Promise<boolean> {
+  const now = Date.now();
+  if (achievementsFlagCache && achievementsFlagCache.expiresAt > now) {
+    return achievementsFlagCache.value;
+  }
+
+  const value = await loadAchievementsFlag();
+  setAchievementsCache(value);
+  return value;
+}
+
+export async function isStreakProtectionEnabled(): Promise<boolean> {
+  const now = Date.now();
+  if (streakProtectionFlagCache && streakProtectionFlagCache.expiresAt > now) {
+    return streakProtectionFlagCache.value;
+  }
+
+  const value = await loadStreakProtectionFlag();
+  setStreakProtectionCache(value);
+  return value;
 }
 
 // Export singleton instance

--- a/src/services/streaks.ts
+++ b/src/services/streaks.ts
@@ -93,36 +93,35 @@ export async function updateStreak(discordId: string, won: boolean): Promise<{ n
     let achievementUnlocked: string | undefined;
 
     if (await areAchievementsEnabled()) {
-
-    if (won && newCurrentWins > userStreak.currentWins) {
-      // Check for streak milestones
-      const streakMilestones = [3, 5, 10, 15, 25, 50, 100];
-      for (const milestone of streakMilestones) {
-        if (newCurrentWins === milestone) {
-          await createAchievement(user.id, "win_streak", milestone, {
-            streak: milestone,
-            date: now.toISOString()
-          });
-          achievementUnlocked = `🔥🐧 ${milestone} Victory Streak!`;
-          break;
-        }
-      }
-
-      // Check for longest streak achievements
-      if (newCurrentWins === newLongestWins && newLongestWins > userStreak.longestWins) {
-        const longestMilestones = [10, 25, 50, 100];
-        for (const milestone of longestMilestones) {
-          if (newLongestWins === milestone) {
-            await createAchievement(user.id, "longest_streak", milestone, {
-              longestStreak: milestone,
+      if (won && newCurrentWins > userStreak.currentWins) {
+        // Check for streak milestones
+        const streakMilestones = [3, 5, 10, 15, 25, 50, 100];
+        for (const milestone of streakMilestones) {
+          if (newCurrentWins === milestone) {
+            await createAchievement(user.id, "win_streak", milestone, {
+              streak: milestone,
               date: now.toISOString()
             });
-            achievementUnlocked = `🏆🐧 Personal Best: ${milestone} Victories!`;
+            achievementUnlocked = `🔥🐧 ${milestone} Victory Streak!`;
             break;
           }
         }
+
+        // Check for longest streak achievements
+        if (newCurrentWins === newLongestWins && newLongestWins > userStreak.longestWins) {
+          const longestMilestones = [10, 25, 50, 100];
+          for (const milestone of longestMilestones) {
+            if (newLongestWins === milestone) {
+              await createAchievement(user.id, "longest_streak", milestone, {
+                longestStreak: milestone,
+                date: now.toISOString()
+              });
+              achievementUnlocked = `🏆🐧 Personal Best: ${milestone} Victories!`;
+              break;
+            }
+          }
+        }
       }
-    }
     } else {
       console.log(`⚠️ Achievements disabled globally - no achievements processed for ${discordId}`);
     }

--- a/src/web/pengubook/routes/markets.ts
+++ b/src/web/pengubook/routes/markets.ts
@@ -1,4 +1,5 @@
 // src/web/pengubook/routes/markets.ts - Prediction markets integration in PenguBook
+import type { PredictionBet } from "@prisma/client";
 import { Request, Response } from "express";
 import { getCurrentUser } from "../../auth.js";
 import { generateBaseHTML } from "../templates.js";
@@ -107,18 +108,6 @@ export async function marketDetailHandler(req: Request, res: Response) {
     const market = await prisma.predictionMarket.findUnique({
       where: { id: marketId },
       include: {
-        bets: include_bets === "true" ? {
-          orderBy: { createdAt: 'desc' },
-          take: 50,
-          include: {
-            User: {
-              select: {
-                username: true,
-                discordId: true
-              }
-            }
-          }
-        } : false,
         _count: {
           select: { bets: true }
         }
@@ -137,6 +126,48 @@ export async function marketDetailHandler(req: Request, res: Response) {
         userId: currentUser.discordId
       }
     });
+
+    let bettingHistory: Array<PredictionBet & { User?: { username: string; discordId: string } | null }> = [];
+
+    if (include_bets === "true") {
+      const bets = await prisma.predictionBet.findMany({
+        where: { marketId },
+        orderBy: { createdAt: 'desc' },
+        take: 50
+      });
+
+      if (bets.length > 0) {
+        const uniqueUserIds = [...new Set(bets.map(bet => bet.userId))];
+
+        const users = await prisma.user.findMany({
+          where: { discordId: { in: uniqueUserIds } },
+          select: {
+            discordId: true,
+            xUsername: true
+          }
+        });
+
+        const userMap = new Map(users.map(user => [user.discordId, user.xUsername ?? null]));
+
+        bettingHistory = bets.map(bet => {
+          const cachedUsername = userMap.get(bet.userId) ?? undefined;
+          const isCurrentUser = bet.userId === currentUser.discordId;
+          const username = cachedUsername
+            ? `@${cachedUsername}`
+            : (isCurrentUser
+              ? currentUser.username || `You (${bet.userId.slice(-4)})`
+              : `User#${bet.userId.slice(-4)}`);
+
+          return {
+            ...bet,
+            User: {
+              username,
+              discordId: bet.userId
+            }
+          };
+        });
+      }
+    }
 
     const marketObj = predictionMarkets['mapDbMarket'](market);
     const odds = predictionMarkets.calculateOdds(marketObj);
@@ -158,7 +189,7 @@ export async function marketDetailHandler(req: Request, res: Response) {
     const content = generateMarketDetailContent(marketWithOdds, {
       userBet,
       currentUser,
-      bettingHistory: market.bets || []
+      bettingHistory
     });
 
     const html = generateBaseHTML(content, `${market.title} - Prediction Markets`, "markets", { user: currentUser });


### PR DESCRIPTION
## Summary
- ensure emergency feature flag cache setters run whenever shutdown, recovery, or kill switch toggles the flags
- expose a utility to clear cached flag values and rely on the helpers when reading flag state
- rebuild PenguBook market bet history by querying bets separately and enriching usernames from stored handles
- tidy the streak achievement branch to keep milestone checks within the enabled guard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34accc8848324ace4e0689a75e8dd