### PR TITLE
Fix PenguBook balances refresh script scope

### DIFF
--- a/dist/web/pengubook/templates.js
+++ b/dist/web/pengubook/templates.js
@@ -377,7 +377,7 @@ export function generateHomeContent(user, currentUser) {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">💰 Wallet Balance</h2>
-                <button onclick="refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
+                <button onclick="window.refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -390,7 +390,7 @@ export function generateHomeContent(user, currentUser) {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">🔥 Recent Activity</h2>
-                <button onclick="refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
+                <button onclick="window.refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -482,20 +482,6 @@ export function generateHomeContent(user, currentUser) {
             <a href="/pengubook/profile" class="pg-btn pg-btn--outline">Set Up Profile</a>
         </div>
         `}
-    </div>`;
-}
-// Generate empty state content
-export function generateEmptyState(icon, title, description, buttonText, buttonLink) {
-    return `
-    <div class="pg-empty-state">
-        <div class="pg-empty-state__icon">${icon}</div>
-        <h2 class="pg-empty-state__title">${title}</h2>
-        <p class="pg-empty-state__description">${description}</p>
-        ${buttonText && buttonLink ? `
-        <div style="margin-top: var(--pg-space-6);">
-            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
-        </div>
-        ` : ''}
     </div>
 
     <script>
@@ -503,6 +489,10 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         async function loadBalances() {
             const container = document.getElementById('balanceContainer');
             const refreshBtn = document.getElementById('refreshBalanceBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -556,6 +546,10 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         async function loadActivity() {
             const container = document.getElementById('activityContainer');
             const refreshBtn = document.getElementById('refreshActivityBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -621,3 +615,18 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         window.refreshActivity = refreshActivity;
     </script>`;
 }
+// Generate empty state content
+export function generateEmptyState(icon, title, description, buttonText, buttonLink) {
+    return `
+    <div class="pg-empty-state">
+        <div class="pg-empty-state__icon">${icon}</div>
+        <h2 class="pg-empty-state__title">${title}</h2>
+        <p class="pg-empty-state__description">${description}</p>
+        ${buttonText && buttonLink ? `
+        <div style="margin-top: var(--pg-space-6);">
+            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
+        </div>
+        ` : ''}
+    </div>`;
+}
+

--- a/src/web/pengubook/templates.ts
+++ b/src/web/pengubook/templates.ts
@@ -382,7 +382,7 @@ export function generateHomeContent(user: any, currentUser: any): string {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">💰 Wallet Balance</h2>
-                <button onclick="refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
+                <button onclick="window.refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -395,7 +395,7 @@ export function generateHomeContent(user: any, currentUser: any): string {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">🔥 Recent Activity</h2>
-                <button onclick="refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
+                <button onclick="window.refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -489,21 +489,6 @@ export function generateHomeContent(user: any, currentUser: any): string {
             <a href="/pengubook/profile" class="pg-btn pg-btn--outline">Set Up Profile</a>
         </div>
         `}
-    </div>`;
-}
-
-// Generate empty state content
-export function generateEmptyState(icon: string, title: string, description: string, buttonText?: string, buttonLink?: string): string {
-  return `
-    <div class="pg-empty-state">
-        <div class="pg-empty-state__icon">${icon}</div>
-        <h2 class="pg-empty-state__title">${title}</h2>
-        <p class="pg-empty-state__description">${description}</p>
-        ${buttonText && buttonLink ? `
-        <div style="margin-top: var(--pg-space-6);">
-            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
-        </div>
-        ` : ''}
     </div>
 
     <script>
@@ -511,6 +496,10 @@ export function generateEmptyState(icon: string, title: string, description: str
         async function loadBalances() {
             const container = document.getElementById('balanceContainer');
             const refreshBtn = document.getElementById('refreshBalanceBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -564,6 +553,10 @@ export function generateEmptyState(icon: string, title: string, description: str
         async function loadActivity() {
             const container = document.getElementById('activityContainer');
             const refreshBtn = document.getElementById('refreshActivityBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -628,4 +621,19 @@ export function generateEmptyState(icon: string, title: string, description: str
         window.refreshBalances = refreshBalances;
         window.refreshActivity = refreshActivity;
     </script>`;
+}
+
+// Generate empty state content
+export function generateEmptyState(icon: string, title: string, description: string, buttonText?: string, buttonLink?: string): string {
+  return `
+    <div class="pg-empty-state">
+        <div class="pg-empty-state__icon">${icon}</div>
+        <h2 class="pg-empty-state__title">${title}</h2>
+        <p class="pg-empty-state__description">${description}</p>
+        ${buttonText && buttonLink ? `
+        <div style="margin-top: var(--pg-space-6);">
+            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
+        </div>
+        ` : ''}
+    </div>`;
 }


### PR DESCRIPTION
## Summary
- expose the balance and activity refresh handlers from the PenguBook home template so the buttons work again
- load the scripts directly on the home page and guard against missing DOM nodes during initialization
- keep the empty state template focused on static markup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3585e0ccc832496bca05545a76d44