### PR TITLE
Show USD values on PenguBook balances

### DIFF
--- a/dist/web/pengubook.js
+++ b/dist/web/pengubook.js
@@ -9,6 +9,7 @@ import { processTip } from "../services/tip_processor.js";
 import { getDiscordClient } from "../services/discord_users.js";
 import { getConfig } from "../config.js";
 import { getReferralStats, createReferralCode } from "../services/referrals.js";
+import { priceAPI } from "../services/price_api.js";
 export const pengubookRouter = Router();
 // Middleware to require authentication for all PenguBook routes
 pengubookRouter.use(requireAuth);
@@ -337,7 +338,56 @@ pengubookRouter.get("/api/balance", async (req, res) => {
             include: { Token: true },
             orderBy: { Token: { symbol: "asc" } }
         });
-        res.json({ success: true, balances });
+        const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+        let priceResult = null;
+        if (tokenSymbols.length > 0) {
+            try {
+                priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+            }
+            catch (error) {
+                console.warn("Failed to fetch USD prices for balances:", error);
+            }
+        }
+        const priceMap = priceResult && priceResult.prices ? priceResult.prices : {};
+        const priceSource = priceResult && priceResult.source ? priceResult.source : "fallback";
+        const formattedBalances = balances.map(balance => {
+            const amountNumber = Number(balance.amount.toString());
+            const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+            const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+            const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+            let formattedUSD = null;
+            if (priceUSD > 0) {
+                if (usdValue === 0) {
+                    formattedUSD = "$0.00";
+                }
+                else if (usdValue < 0.01) {
+                    formattedUSD = "< $0.01";
+                }
+                else {
+                    formattedUSD = `$${usdValue.toFixed(2)}`;
+                }
+            }
+            return {
+                ...balance,
+                amount,
+                priceUSD: priceUSD > 0 ? priceUSD : null,
+                usdValue,
+                formattedUSD
+            };
+        });
+        const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+        const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+        const priceDisclaimer = tokenSymbols.length > 0
+            ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+            : null;
+        res.json({
+            success: true,
+            balances: formattedBalances,
+            totalUSD,
+            formattedTotalUSD,
+            priceSource,
+            priceDisclaimer
+        });
     }
     catch (error) {
         console.error("Balance fetch error:", error);

--- a/dist/web/pengubook/routes/api.js
+++ b/dist/web/pengubook/routes/api.js
@@ -3,6 +3,7 @@ import { getUnreadMessageCount } from "../../../interactions/buttons/pengubook.j
 import { getDiscordClient } from "../../../services/discord_users.js";
 import { findOrCreateUser } from "../../../services/user_helpers.js";
 import { prisma } from "../../../services/db.js";
+import { priceAPI } from "../../../services/price_api.js";
 export const apiHandlers = {
     // GET /pengubook/api/unread-count
     async unreadCount(req, res) {
@@ -119,16 +120,57 @@ export const apiHandlers = {
                 include: { Token: true },
                 orderBy: { Token: { symbol: "asc" } }
             });
-            // Format balances with max 2 decimal places, remove trailing zeros
+            const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+            let priceResult = null;
+            if (tokenSymbols.length > 0) {
+                try {
+                    priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+                }
+                catch (error) {
+                    console.warn("Failed to fetch USD prices for balances:", error);
+                }
+            }
+            const priceMap = priceResult && priceResult.prices ? priceResult.prices : {};
+            const priceSource = priceResult && priceResult.source ? priceResult.source : "fallback";
+            // Format balances with max 2 decimal places, remove trailing zeros, and attach USD estimates
             const formattedBalances = balances.map(balance => {
-                const amount = Number(balance.amount.toString());
-                const formatted = amount.toFixed(2).replace(/\.?0+$/, "");
+                const amountNumber = Number(balance.amount.toString());
+                const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+                const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+                const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+                let formattedUSD = null;
+                if (priceUSD > 0) {
+                    if (usdValue === 0) {
+                        formattedUSD = "$0.00";
+                    }
+                    else if (usdValue < 0.01) {
+                        formattedUSD = "< $0.01";
+                    }
+                    else {
+                        formattedUSD = `$${usdValue.toFixed(2)}`;
+                    }
+                }
                 return {
                     ...balance,
-                    amount: formatted
+                    amount,
+                    priceUSD: priceUSD > 0 ? priceUSD : null,
+                    usdValue,
+                    formattedUSD
                 };
             });
-            res.json({ success: true, balances: formattedBalances });
+            const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+            const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+            const priceDisclaimer = tokenSymbols.length > 0
+                ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+                : null;
+            res.json({
+                success: true,
+                balances: formattedBalances,
+                totalUSD,
+                formattedTotalUSD,
+                priceSource,
+                priceDisclaimer
+            });
         }
         catch (error) {
             console.error("Balance fetch error:", error);

--- a/dist/web/pengubook/routes/profile.js
+++ b/dist/web/pengubook/routes/profile.js
@@ -309,9 +309,23 @@ export async function profileHandler(req, res) {
                                 <div class="pg-balance-item">
                                     <div class="pg-balance-amount">\${balance.amount}</div>
                                     <div class="pg-balance-token">\${balance.Token.symbol}</div>
+                                    <div class="pg-balance-usd" style="margin-top: 4px; font-size: var(--pg-text-xs); color: var(--pg-dark-500);">
+                                        \${balance.formattedUSD ? \`\${balance.formattedUSD} USD\` : 'USD price unavailable'}
+                                    </div>
                                 </div>
                             \`).join('')}
                         </div>
+                        \${data.formattedTotalUSD ? \`
+                        <div style="margin-top: var(--pg-space-4); padding-top: var(--pg-space-3); border-top: 1px solid var(--pg-dark-300); display: flex; justify-content: space-between; align-items: center; font-size: var(--pg-text-sm);">
+                            <span style="color: var(--pg-dark-500);">Total USD Value</span>
+                            <strong style="color: var(--pg-dark-800);">\${data.formattedTotalUSD} USD</strong>
+                        </div>
+                        \` : ''}
+                        \${data.priceDisclaimer ? \`
+                        <div style="margin-top: var(--pg-space-2); font-size: var(--pg-text-xs); color: var(--pg-dark-400);">
+                            \${data.priceDisclaimer}
+                        </div>
+                        \` : ''}
                     \`;
                     container.innerHTML = balanceHTML;
                 } else {

--- a/dist/web/pengubook/templates.js
+++ b/dist/web/pengubook/templates.js
@@ -377,7 +377,7 @@ export function generateHomeContent(user, currentUser) {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">💰 Wallet Balance</h2>
-                <button onclick="refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
+                <button onclick="window.refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -390,7 +390,7 @@ export function generateHomeContent(user, currentUser) {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">🔥 Recent Activity</h2>
-                <button onclick="refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
+                <button onclick="window.refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -482,20 +482,6 @@ export function generateHomeContent(user, currentUser) {
             <a href="/pengubook/profile" class="pg-btn pg-btn--outline">Set Up Profile</a>
         </div>
         `}
-    </div>`;
-}
-// Generate empty state content
-export function generateEmptyState(icon, title, description, buttonText, buttonLink) {
-    return `
-    <div class="pg-empty-state">
-        <div class="pg-empty-state__icon">${icon}</div>
-        <h2 class="pg-empty-state__title">${title}</h2>
-        <p class="pg-empty-state__description">${description}</p>
-        ${buttonText && buttonLink ? `
-        <div style="margin-top: var(--pg-space-6);">
-            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
-        </div>
-        ` : ''}
     </div>
 
     <script>
@@ -503,6 +489,10 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         async function loadBalances() {
             const container = document.getElementById('balanceContainer');
             const refreshBtn = document.getElementById('refreshBalanceBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -518,9 +508,23 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
                                 <div class="pg-balance-item">
                                     <div class="pg-balance-amount">\${balance.amount}</div>
                                     <div class="pg-balance-token">\${balance.Token.symbol}</div>
+                                    <div class="pg-balance-usd" style="margin-top: 4px; font-size: var(--pg-text-xs); color: var(--pg-dark-500);">
+                                        \${balance.formattedUSD ? \`\${balance.formattedUSD} USD\` : 'USD price unavailable'}
+                                    </div>
                                 </div>
                             \`).join('')}
                         </div>
+                        \${data.formattedTotalUSD ? \`
+                        <div style="margin-top: var(--pg-space-4); padding-top: var(--pg-space-3); border-top: 1px solid var(--pg-dark-300); display: flex; justify-content: space-between; align-items: center; font-size: var(--pg-text-sm);">
+                            <span style="color: var(--pg-dark-500);">Total USD Value</span>
+                            <strong style="color: var(--pg-dark-800);">\${data.formattedTotalUSD} USD</strong>
+                        </div>
+                        \` : ''}
+                        \${data.priceDisclaimer ? \`
+                        <div style="margin-top: var(--pg-space-2); font-size: var(--pg-text-xs); color: var(--pg-dark-400);">
+                            \${data.priceDisclaimer}
+                        </div>
+                        \` : ''}
                     \`;
                     container.innerHTML = balanceHTML;
                 } else {
@@ -556,6 +560,10 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         async function loadActivity() {
             const container = document.getElementById('activityContainer');
             const refreshBtn = document.getElementById('refreshActivityBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -621,3 +629,18 @@ export function generateEmptyState(icon, title, description, buttonText, buttonL
         window.refreshActivity = refreshActivity;
     </script>`;
 }
+// Generate empty state content
+export function generateEmptyState(icon, title, description, buttonText, buttonLink) {
+    return `
+    <div class="pg-empty-state">
+        <div class="pg-empty-state__icon">${icon}</div>
+        <h2 class="pg-empty-state__title">${title}</h2>
+        <p class="pg-empty-state__description">${description}</p>
+        ${buttonText && buttonLink ? `
+        <div style="margin-top: var(--pg-space-6);">
+            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
+        </div>
+        ` : ''}
+    </div>`;
+}
+

--- a/dist/web/pengubook_enhanced.js
+++ b/dist/web/pengubook_enhanced.js
@@ -9,6 +9,7 @@ import { processTip } from "../services/tip_processor.js";
 import { getDiscordClient } from "../services/discord_users.js";
 import { getConfig } from "../config.js";
 import { getReferralStats, createReferralCode } from "../services/referrals.js";
+import { priceAPI } from "../services/price_api.js";
 import fs from "fs";
 import path from "path";
 export const pengubookEnhancedRouter = Router();
@@ -1152,7 +1153,56 @@ pengubookEnhancedRouter.get("/api/balance", async (req, res) => {
             include: { Token: true },
             orderBy: { Token: { symbol: "asc" } }
         });
-        res.json({ success: true, balances });
+        const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+        let priceResult = null;
+        if (tokenSymbols.length > 0) {
+            try {
+                priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+            }
+            catch (error) {
+                console.warn("Failed to fetch USD prices for balances:", error);
+            }
+        }
+        const priceMap = priceResult && priceResult.prices ? priceResult.prices : {};
+        const priceSource = priceResult && priceResult.source ? priceResult.source : "fallback";
+        const formattedBalances = balances.map(balance => {
+            const amountNumber = Number(balance.amount.toString());
+            const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+            const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+            const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+            let formattedUSD = null;
+            if (priceUSD > 0) {
+                if (usdValue === 0) {
+                    formattedUSD = "$0.00";
+                }
+                else if (usdValue < 0.01) {
+                    formattedUSD = "< $0.01";
+                }
+                else {
+                    formattedUSD = `$${usdValue.toFixed(2)}`;
+                }
+            }
+            return {
+                ...balance,
+                amount,
+                priceUSD: priceUSD > 0 ? priceUSD : null,
+                usdValue,
+                formattedUSD
+            };
+        });
+        const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+        const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+        const priceDisclaimer = tokenSymbols.length > 0
+            ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+            : null;
+        res.json({
+            success: true,
+            balances: formattedBalances,
+            totalUSD,
+            formattedTotalUSD,
+            priceSource,
+            priceDisclaimer
+        });
     }
     catch (error) {
         console.error("Balance fetch error:", error);

--- a/src/web/pengubook.ts
+++ b/src/web/pengubook.ts
@@ -9,6 +9,7 @@ import { processTip } from "../services/tip_processor.js";
 import { getDiscordClient } from "../services/discord_users.js";
 import { getConfig } from "../config.js";
 import { getReferralStats, createReferralCode } from "../services/referrals.js";
+import { priceAPI } from "../services/price_api.js";
 
 export const pengubookRouter = Router();
 
@@ -384,7 +385,62 @@ pengubookRouter.get("/api/balance", async (req: Request, res: Response) => {
       orderBy: { Token: { symbol: "asc" } }
     });
 
-    res.json({ success: true, balances });
+    const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+
+    let priceResult: { prices: Record<string, number>; source: string } | null = null;
+
+    if (tokenSymbols.length > 0) {
+      try {
+        priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+      } catch (error) {
+        console.warn("Failed to fetch USD prices for balances:", error);
+      }
+    }
+
+    const priceMap = priceResult?.prices ?? {};
+    const priceSource = priceResult?.source ?? "fallback";
+
+    const formattedBalances = balances.map(balance => {
+      const amountNumber = Number(balance.amount.toString());
+      const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+
+      const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+      const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+
+      let formattedUSD: string | null = null;
+      if (priceUSD > 0) {
+        if (usdValue === 0) {
+          formattedUSD = "$0.00";
+        } else if (usdValue < 0.01) {
+          formattedUSD = "< $0.01";
+        } else {
+          formattedUSD = `$${usdValue.toFixed(2)}`;
+        }
+      }
+
+      return {
+        ...balance,
+        amount,
+        priceUSD: priceUSD > 0 ? priceUSD : null,
+        usdValue,
+        formattedUSD
+      };
+    });
+
+    const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+    const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+    const priceDisclaimer = tokenSymbols.length > 0
+      ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+      : null;
+
+    res.json({
+      success: true,
+      balances: formattedBalances,
+      totalUSD,
+      formattedTotalUSD,
+      priceSource,
+      priceDisclaimer
+    });
   } catch (error) {
     console.error("Balance fetch error:", error);
     res.status(500).json({ success: false, error: "Failed to fetch balance" });

--- a/src/web/pengubook/routes/api.ts
+++ b/src/web/pengubook/routes/api.ts
@@ -5,6 +5,7 @@ import { getUnreadMessageCount } from "../../../interactions/buttons/pengubook.j
 import { getDiscordClient } from "../../../services/discord_users.js";
 import { findOrCreateUser } from "../../../services/user_helpers.js";
 import { prisma } from "../../../services/db.js";
+import { priceAPI } from "../../../services/price_api.js";
 
 export const apiHandlers = {
   // GET /pengubook/api/unread-count
@@ -130,17 +131,63 @@ export const apiHandlers = {
         orderBy: { Token: { symbol: "asc" } }
       });
 
-      // Format balances with max 2 decimal places, remove trailing zeros
+      const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+
+      let priceResult: { prices: Record<string, number>; source: string } | null = null;
+
+      if (tokenSymbols.length > 0) {
+        try {
+          priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+        } catch (error) {
+          console.warn("Failed to fetch USD prices for balances:", error);
+        }
+      }
+
+      const priceMap = priceResult?.prices ?? {};
+      const priceSource = priceResult?.source ?? "fallback";
+
+      // Format balances with max 2 decimal places, remove trailing zeros, and attach USD estimates
       const formattedBalances = balances.map(balance => {
-        const amount = Number(balance.amount.toString());
-        const formatted = amount.toFixed(2).replace(/\.?0+$/, "");
+        const amountNumber = Number(balance.amount.toString());
+        const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+
+        const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+        const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+
+        let formattedUSD: string | null = null;
+        if (priceUSD > 0) {
+          if (usdValue === 0) {
+            formattedUSD = "$0.00";
+          } else if (usdValue < 0.01) {
+            formattedUSD = "< $0.01";
+          } else {
+            formattedUSD = `$${usdValue.toFixed(2)}`;
+          }
+        }
+
         return {
           ...balance,
-          amount: formatted
+          amount,
+          priceUSD: priceUSD > 0 ? priceUSD : null,
+          usdValue,
+          formattedUSD
         };
       });
 
-      res.json({ success: true, balances: formattedBalances });
+      const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+      const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+      const priceDisclaimer = tokenSymbols.length > 0
+        ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+        : null;
+
+      res.json({
+        success: true,
+        balances: formattedBalances,
+        totalUSD,
+        formattedTotalUSD,
+        priceSource,
+        priceDisclaimer
+      });
     } catch (error) {
       console.error("Balance fetch error:", error);
       res.status(500).json({ success: false, error: "Failed to fetch balance" });

--- a/src/web/pengubook/routes/profile.ts
+++ b/src/web/pengubook/routes/profile.ts
@@ -314,9 +314,23 @@ export async function profileHandler(req: Request, res: Response) {
                                 <div class="pg-balance-item">
                                     <div class="pg-balance-amount">\${balance.amount}</div>
                                     <div class="pg-balance-token">\${balance.Token.symbol}</div>
+                                    <div class="pg-balance-usd" style="margin-top: 4px; font-size: var(--pg-text-xs); color: var(--pg-dark-500);">
+                                        \${balance.formattedUSD ? \`\${balance.formattedUSD} USD\` : 'USD price unavailable'}
+                                    </div>
                                 </div>
                             \`).join('')}
                         </div>
+                        \${data.formattedTotalUSD ? \`
+                        <div style="margin-top: var(--pg-space-4); padding-top: var(--pg-space-3); border-top: 1px solid var(--pg-dark-300); display: flex; justify-content: space-between; align-items: center; font-size: var(--pg-text-sm);">
+                            <span style="color: var(--pg-dark-500);">Total USD Value</span>
+                            <strong style="color: var(--pg-dark-800);">\${data.formattedTotalUSD} USD</strong>
+                        </div>
+                        \` : ''}
+                        \${data.priceDisclaimer ? \`
+                        <div style="margin-top: var(--pg-space-2); font-size: var(--pg-text-xs); color: var(--pg-dark-400);">
+                            \${data.priceDisclaimer}
+                        </div>
+                        \` : ''}
                     \`;
                     container.innerHTML = balanceHTML;
                 } else {

--- a/src/web/pengubook/templates.ts
+++ b/src/web/pengubook/templates.ts
@@ -382,7 +382,7 @@ export function generateHomeContent(user: any, currentUser: any): string {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">💰 Wallet Balance</h2>
-                <button onclick="refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
+                <button onclick="window.refreshBalances()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshBalanceBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -395,7 +395,7 @@ export function generateHomeContent(user: any, currentUser: any): string {
         <div class="pg-card" style="margin-bottom: var(--pg-space-6);">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--pg-space-4);">
                 <h2 style="margin: 0; color: var(--pg-dark-800);">🔥 Recent Activity</h2>
-                <button onclick="refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
+                <button onclick="window.refreshActivity()" class="pg-btn pg-btn--secondary pg-btn--sm" id="refreshActivityBtn">
                     🔄 Refresh
                 </button>
             </div>
@@ -489,21 +489,6 @@ export function generateHomeContent(user: any, currentUser: any): string {
             <a href="/pengubook/profile" class="pg-btn pg-btn--outline">Set Up Profile</a>
         </div>
         `}
-    </div>`;
-}
-
-// Generate empty state content
-export function generateEmptyState(icon: string, title: string, description: string, buttonText?: string, buttonLink?: string): string {
-  return `
-    <div class="pg-empty-state">
-        <div class="pg-empty-state__icon">${icon}</div>
-        <h2 class="pg-empty-state__title">${title}</h2>
-        <p class="pg-empty-state__description">${description}</p>
-        ${buttonText && buttonLink ? `
-        <div style="margin-top: var(--pg-space-6);">
-            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
-        </div>
-        ` : ''}
     </div>
 
     <script>
@@ -511,6 +496,10 @@ export function generateEmptyState(icon: string, title: string, description: str
         async function loadBalances() {
             const container = document.getElementById('balanceContainer');
             const refreshBtn = document.getElementById('refreshBalanceBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -526,9 +515,23 @@ export function generateEmptyState(icon: string, title: string, description: str
                                 <div class="pg-balance-item">
                                     <div class="pg-balance-amount">\${balance.amount}</div>
                                     <div class="pg-balance-token">\${balance.Token.symbol}</div>
+                                    <div class="pg-balance-usd" style="margin-top: 4px; font-size: var(--pg-text-xs); color: var(--pg-dark-500);">
+                                        \${balance.formattedUSD ? \`\${balance.formattedUSD} USD\` : 'USD price unavailable'}
+                                    </div>
                                 </div>
                             \`).join('')}
                         </div>
+                        \${data.formattedTotalUSD ? \`
+                        <div style="margin-top: var(--pg-space-4); padding-top: var(--pg-space-3); border-top: 1px solid var(--pg-dark-300); display: flex; justify-content: space-between; align-items: center; font-size: var(--pg-text-sm);">
+                            <span style="color: var(--pg-dark-500);">Total USD Value</span>
+                            <strong style="color: var(--pg-dark-800);">\${data.formattedTotalUSD} USD</strong>
+                        </div>
+                        \` : ''}
+                        \${data.priceDisclaimer ? \`
+                        <div style="margin-top: var(--pg-space-2); font-size: var(--pg-text-xs); color: var(--pg-dark-400);">
+                            \${data.priceDisclaimer}
+                        </div>
+                        \` : ''}
                     \`;
                     container.innerHTML = balanceHTML;
                 } else {
@@ -564,6 +567,10 @@ export function generateEmptyState(icon: string, title: string, description: str
         async function loadActivity() {
             const container = document.getElementById('activityContainer');
             const refreshBtn = document.getElementById('refreshActivityBtn');
+
+            if (!container || !refreshBtn) {
+                return;
+            }
 
             try {
                 refreshBtn.disabled = true;
@@ -628,4 +635,19 @@ export function generateEmptyState(icon: string, title: string, description: str
         window.refreshBalances = refreshBalances;
         window.refreshActivity = refreshActivity;
     </script>`;
+}
+
+// Generate empty state content
+export function generateEmptyState(icon: string, title: string, description: string, buttonText?: string, buttonLink?: string): string {
+  return `
+    <div class="pg-empty-state">
+        <div class="pg-empty-state__icon">${icon}</div>
+        <h2 class="pg-empty-state__title">${title}</h2>
+        <p class="pg-empty-state__description">${description}</p>
+        ${buttonText && buttonLink ? `
+        <div style="margin-top: var(--pg-space-6);">
+            <a href="${buttonLink}" class="pg-btn pg-btn--primary">${buttonText}</a>
+        </div>
+        ` : ''}
+    </div>`;
 }

--- a/src/web/pengubook_enhanced.ts
+++ b/src/web/pengubook_enhanced.ts
@@ -9,6 +9,7 @@ import { processTip } from "../services/tip_processor.js";
 import { getDiscordClient } from "../services/discord_users.js";
 import { getConfig } from "../config.js";
 import { getReferralStats, createReferralCode } from "../services/referrals.js";
+import { priceAPI } from "../services/price_api.js";
 import fs from "fs";
 import path from "path";
 
@@ -1211,7 +1212,62 @@ pengubookEnhancedRouter.get("/api/balance", async (req: Request, res: Response) 
       orderBy: { Token: { symbol: "asc" } }
     });
 
-    res.json({ success: true, balances });
+    const tokenSymbols = Array.from(new Set(balances.map(balance => balance.Token.symbol)));
+
+    let priceResult: { prices: Record<string, number>; source: string } | null = null;
+
+    if (tokenSymbols.length > 0) {
+      try {
+        priceResult = await priceAPI.getTokenPrices(tokenSymbols);
+      } catch (error) {
+        console.warn("Failed to fetch USD prices for balances:", error);
+      }
+    }
+
+    const priceMap = priceResult?.prices ?? {};
+    const priceSource = priceResult?.source ?? "fallback";
+
+    const formattedBalances = balances.map(balance => {
+      const amountNumber = Number(balance.amount.toString());
+      const amount = amountNumber.toFixed(2).replace(/\.?0+$/, "");
+
+      const priceUSD = priceMap[balance.Token.symbol] ?? 0;
+      const usdValue = priceUSD > 0 ? amountNumber * priceUSD : 0;
+
+      let formattedUSD: string | null = null;
+      if (priceUSD > 0) {
+        if (usdValue === 0) {
+          formattedUSD = "$0.00";
+        } else if (usdValue < 0.01) {
+          formattedUSD = "< $0.01";
+        } else {
+          formattedUSD = `$${usdValue.toFixed(2)}`;
+        }
+      }
+
+      return {
+        ...balance,
+        amount,
+        priceUSD: priceUSD > 0 ? priceUSD : null,
+        usdValue,
+        formattedUSD
+      };
+    });
+
+    const totalUSD = formattedBalances.reduce((sum, balance) => sum + (balance.usdValue || 0), 0);
+    const formattedTotalUSD = totalUSD > 0 ? `$${totalUSD.toFixed(2)}` : null;
+    const priceDisclaimer = tokenSymbols.length > 0
+      ? `USD estimates via ${priceSource.toUpperCase()}${priceSource === "fallback" ? " (estimates only)" : ""}`
+      : null;
+
+    res.json({
+      success: true,
+      balances: formattedBalances,
+      totalUSD,
+      formattedTotalUSD,
+      priceSource,
+      priceDisclaimer
+    });
   } catch (error) {
     console.error("Balance fetch error:", error);
     res.status(500).json({ success: false, error: "Failed to fetch balance" });


### PR DESCRIPTION
## Summary
- integrate the priceAPI into each PenguBook balance endpoint so responses include USD estimates, totals, and source disclaimers
- surface the per-token USD amounts, total USD value, and pricing disclaimer on the home and profile balance widgets
- regenerate the compiled PenguBook bundles to mirror the new API payload and client rendering changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3585e0ccc832496bca05545a76d44