### PR TITLE
Add legacy market redirects for bet and create routes

### DIFF
--- a/dist/web/pengubook/routes/markets.js
+++ b/dist/web/pengubook/routes/markets.js
@@ -28,3 +28,36 @@ export async function marketDetailHandler(req, res) {
         res.status(500).send('Error redirecting to PIPChips market');
     }
 }
+// Legacy bet placement handler - redirect to the new PIPChips market flow
+export async function placeBetHandler(req, res) {
+    try {
+        const currentUser = getCurrentUser(req);
+        if (!currentUser) {
+            return res.redirect("/auth/discord");
+        }
+        const marketId = req.body?.marketId ?? req.query?.marketId;
+        if (marketId) {
+            return res.redirect(`/pengubook/pipchips-markets/${marketId}`);
+        }
+        return res.redirect("/pengubook/pipchips-markets");
+    }
+    catch (error) {
+        console.error('Legacy bet placement redirect error:', error);
+        res.status(500).send('Error redirecting to PIPChips markets');
+    }
+}
+// Legacy market creation handler - redirect to the PIPChips markets page
+export async function createMarketHandler(req, res) {
+    try {
+        const currentUser = getCurrentUser(req);
+        if (!currentUser) {
+            return res.redirect("/auth/discord");
+        }
+        return res.redirect("/pengubook/pipchips-markets");
+    }
+    catch (error) {
+        console.error('Legacy market creation redirect error:', error);
+        res.status(500).send('Error redirecting to PIPChips markets');
+    }
+}
+

--- a/src/web/pengubook/routes/markets.ts
+++ b/src/web/pengubook/routes/markets.ts
@@ -34,3 +34,40 @@ export async function marketDetailHandler(req: Request, res: Response) {
     res.status(500).send('Error redirecting to PIPChips market');
   }
 }
+
+// Legacy bet placement handler - redirect to the new PIPChips market flow
+export async function placeBetHandler(req: Request, res: Response) {
+  try {
+    const currentUser = getCurrentUser(req);
+    if (!currentUser) {
+      return res.redirect("/auth/discord");
+    }
+
+    const marketId = req.body?.marketId ?? req.query?.marketId;
+    if (marketId) {
+      return res.redirect(`/pengubook/pipchips-markets/${marketId}`);
+    }
+
+    return res.redirect("/pengubook/pipchips-markets");
+
+  } catch (error) {
+    console.error('Legacy bet placement redirect error:', error);
+    res.status(500).send('Error redirecting to PIPChips markets');
+  }
+}
+
+// Legacy market creation handler - redirect to the PIPChips markets page
+export async function createMarketHandler(req: Request, res: Response) {
+  try {
+    const currentUser = getCurrentUser(req);
+    if (!currentUser) {
+      return res.redirect("/auth/discord");
+    }
+
+    return res.redirect("/pengubook/pipchips-markets");
+
+  } catch (error) {
+    console.error('Legacy market creation redirect error:', error);
+    res.status(500).send('Error redirecting to PIPChips markets');
+  }
+}


### PR DESCRIPTION
## Summary
- add legacy PenguBook market handlers that redirect bet and create requests to the new PIPChips markets
- ensure both TypeScript source and compiled JavaScript exports the new handlers to satisfy router imports

## Testing
- npm run build *(fails: existing TypeScript errors in pipchips market files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d45a267d788324ae42ab672eec788a